### PR TITLE
Separar contenido para las diferentes vistas

### DIFF
--- a/src/components/authentication/AuthSocial.js
+++ b/src/components/authentication/AuthSocial.js
@@ -53,6 +53,7 @@ function AuthSocial() {
       cookies.set('UserCode', code, { path: '/' });
       cookies.set('UserType', type, { path: '/' });
       navigate('/dashboard', { replace: true });
+      window.location.reload();
     } if (isFind && status === "I") {
       setShowAlert({
         message: 'No puedes ingresar a tu cuenta, contacta a tu administrador de sistema para mayor información',
@@ -134,13 +135,13 @@ function AuthSocial() {
 
       {
         showAlert.show
-        ?
+          ?
           <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'right' }} open={openAlert} autoHideDuration={showAlert.duration} onClose={handleCloseAlert}>
             <Alert onClose={handleCloseAlert} severity="error" sx={{ width: '100%' }}>
               {showAlert.message}
             </Alert>
           </Snackbar>
-        :
+          :
           null
       }
     </>

--- a/src/components/authentication/login/LoginForm.js
+++ b/src/components/authentication/login/LoginForm.js
@@ -64,6 +64,7 @@ function LoginForm() {
             cookies.set('UserCode', code, { path: '/' });
             cookies.set('UserType', type, { path: '/' });
             navigate('/dashboard', { replace: true });
+            window.location.reload();
           } else {
             setShowAlert({
               message: 'No puedes ingresar a tu cuenta, contacta a tu administrador de sistema para mayor información',
@@ -102,7 +103,7 @@ function LoginForm() {
   var type = "";
   var correctPassword = false;
   var status = "";
-  
+
   const searchUser = (finded) => {
     user.filter((element) => {
       if (element.userx_email.toLowerCase() === finded.toLowerCase()) {
@@ -188,13 +189,13 @@ function LoginForm() {
         </LoadingButton>
         {
           showAlert.show
-          ?
+            ?
             <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'right' }} open={open} autoHideDuration={showAlert.duration} onClose={handleClose}>
               <Alert onClose={handleClose} severity="error" sx={{ width: '100%', boxShadow: 10 }}>
                 {showAlert.message}
               </Alert>
             </Snackbar>
-          :
+            :
             null
         }
       </Form>

--- a/src/components/authentication/scannerLogin/Scanner.js
+++ b/src/components/authentication/scannerLogin/Scanner.js
@@ -27,7 +27,7 @@ function Scanner() {
   useEffect(() => {
     peticionesGet();
   }, []);
-  
+
   var isFind = false;
 
   const searchUser = (finded) => {
@@ -43,6 +43,7 @@ function Scanner() {
                 cookies.set('UserType', Response.data.userx_type, { path: '/' });
                 Quagga.stop();
                 navigate('/dashboard', { replace: true });
+                window.location.reload();
               }).catch(error => {
                 console.log(error);
               })
@@ -79,11 +80,11 @@ function Scanner() {
       {
         activeAlert.show
           ?
-            <Alert border-radius="12px" severity="error" sx={{boxShadow: 4}}>
-              {activeAlert.message}
-            </Alert>
+          <Alert border-radius="12px" severity="error" sx={{ boxShadow: 4 }}>
+            {activeAlert.message}
+          </Alert>
           :
-            <Alert border-radius="12px" severity="info" sx={{boxShadow: 4}}>Escaneando credencial...</Alert>
+          <Alert border-radius="12px" severity="info" sx={{ boxShadow: 4 }}>Escaneando credencial...</Alert>
       }
       <br></br>
       <ScannerQuagga onDetected={_onDetected} />

--- a/src/layouts/dashboard/SidebarConfig.js
+++ b/src/layouts/dashboard/SidebarConfig.js
@@ -7,55 +7,106 @@ import bookFill from '@iconify/icons-eva/book-fill';
 import clipBoardFill from '@iconify/icons-eva/clipboard-fill';
 import calendarFill from '@iconify/icons-eva/calendar-fill';
 import infoFill from '@iconify/icons-eva/info-fill';
+import Cookies from 'universal-cookie';
 
 const getIcon = (name) => <Icon icon={name} width={22} height={22} />;
+const cookies = new Cookies();
 
-const sidebarConfig = [
-  {
-    title: 'tablero',
-    path: '/dashboard/app',
-    icon: getIcon(gridFill)
-  },
-  {
-    title: 'usuarios',
-    path: '/dashboard/user',
-    icon: getIcon(peopleFill)
-  },
-  {
-    title: 'asesores',
-    path: '/dashboard/adviser',
-    icon: getIcon(personDoneFill)
-  },
-  {
-    title: 'materias',
-    path: '/dashboard/subject',
-    icon: getIcon(fileTextFill)
-  },
-  {
-    title: 'añadir asesoría',
-    path: '/dashboard/new-advise',
-    icon: getIcon(fileTextFill)
-  },
-  {
-    title: 'asesorias',
-    path: '/dashboard/advises',
-    icon: getIcon(bookFill)
-  },
-  {
-    title: 'reportes',
-    path: '/dashboard/reports',
-    icon: getIcon(clipBoardFill)
-  },
-  {
-    title: 'Calendario',
-    path: '/dashboard/calendar',
-    icon: getIcon(calendarFill)
-  },
-  {
-    title: 'acerca de',
-    path: '/comming',
-    icon: getIcon(infoFill)
+function uploadMenu(type) {
+  if (type === 'N') {
+    return (
+      [
+        {
+          title: 'tablero',
+          path: '/dashboard/app',
+          icon: getIcon(gridFill)
+        },
+        {
+          title: 'asesores',
+          path: '/dashboard/adviser',
+          icon: getIcon(personDoneFill)
+        },
+        {
+          title: 'materias',
+          path: '/dashboard/subject',
+          icon: getIcon(fileTextFill)
+        },
+        {
+          title: 'asesorias',
+          path: '/dashboard/advises',
+          icon: getIcon(bookFill)
+        },
+        {
+          title: 'Calendario',
+          path: '/dashboard/calendar',
+          icon: getIcon(calendarFill)
+        },
+        {
+          title: 'acerca de',
+          path: '/comming',
+          icon: getIcon(infoFill)
+        }
+      ]
+    );
+  } else if (type === 'A') {
+    return (
+      [
+        {
+          title: 'tablero',
+          path: '/dashboard/app',
+          icon: getIcon(gridFill)
+        },
+        {
+          title: 'añadir asesoría',
+          path: '/dashboard/new-advise',
+          icon: getIcon(fileTextFill)
+        },
+        {
+          title: 'reportes',
+          path: '/dashboard/reports',
+          icon: getIcon(clipBoardFill)
+        },
+        {
+          title: 'Calendario',
+          path: '/dashboard/calendar',
+          icon: getIcon(calendarFill)
+        },
+        {
+          title: 'acerca de',
+          path: '/comming',
+          icon: getIcon(infoFill)
+        }
+      ]
+    );
+  } else if (type === 'S') {
+    return (
+      [
+        {
+          title: 'tablero',
+          path: '/dashboard/app',
+          icon: getIcon(gridFill)
+        },
+        {
+          title: 'usuarios',
+          path: '/dashboard/user',
+          icon: getIcon(peopleFill)
+        },
+        {
+          title: 'reportes',
+          path: '/dashboard/reports',
+          icon: getIcon(clipBoardFill)
+        },
+        {
+          title: 'acerca de',
+          path: '/comming',
+          icon: getIcon(infoFill)
+        }
+      ]
+    );
   }
-];
+}
+
+const sidebarConfig = uploadMenu(cookies.get('UserType'));
+
 
 export default sidebarConfig;

--- a/src/pages/Advisers.js
+++ b/src/pages/Advisers.js
@@ -20,6 +20,8 @@ function Advisers() {
     useEffect(() => {
         if (!cookies.get('UserCode')) {
             navigate('/');
+        } else if (cookies.get('UserType') !== 'N') {
+            navigate('/dashboard');
         }
     });
 
@@ -78,9 +80,9 @@ function Advisers() {
                 <Grid container spacing={3}>
                     {
                         noRequest
-                        ?
+                            ?
                             <Wrong />
-                        :
+                            :
                             advisers.map(elemento => (
                                 <Grid item xs={12} sm={6} md={3}>
                                     <Card>

--- a/src/pages/Advises.js
+++ b/src/pages/Advises.js
@@ -23,9 +23,11 @@ function Advises() {
     useEffect(() => {
         if (!cookies.get('UserCode')) {
             navigate('/');
+        } else if (cookies.get('UserType') !== 'N') {
+            navigate('/dashboard');
         }
     });
-    
+
     const requestGet = async () => {
         await axios.get(`${WS_PATH}advises`)
             .then(response => {
@@ -48,12 +50,12 @@ function Advises() {
     const filterAdvises = () => {
         var data = [];
         advise.filter((element) => {
-            if(idSubject !== undefined){
-                if(idUser !== undefined){
-                    if(idSubject.match(element.advise_subject) && idUser.match(element.advise_advisor)){
+            if (idSubject !== undefined) {
+                if (idUser !== undefined) {
+                    if (idSubject.match(element.advise_subject) && idUser.match(element.advise_advisor)) {
                         data.push(element);
                     }
-                } else if(idSubject.match(element.advise_subject)){
+                } else if (idSubject.match(element.advise_subject)) {
                     data.push(element);
                 }
 
@@ -77,9 +79,9 @@ function Advises() {
                 <Grid container spacing={3}>
                     {
                         noRequest
-                        ?
+                            ?
                             <Wrong />
-                        :
+                            :
                             filterAdvises().map(element => (
                                 <Grid item xs={12} sm={6} md={4}>
                                     <Card>

--- a/src/pages/Calendar.js
+++ b/src/pages/Calendar.js
@@ -57,6 +57,8 @@ function Calendar() {
     useEffect(() => {
         if (!cookies.get('UserCode')) {
             navigate('/');
+        } else if (cookies.get('UserType') === 'S') {
+            navigate('/dashboard');
         }
     });
 

--- a/src/pages/DashboardApp.js
+++ b/src/pages/DashboardApp.js
@@ -2,10 +2,12 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, Grid, Container, Typography } from '@mui/material';
 import Page from '../components/Page';
-import { AcceptedAdvice, CanceledAdvise, RequestedAdvice, TotalAdvice,
-  AdviseOfTheDay, UserDistribution, CarouselInfographics, WebAppAdvise } from '../components/_dashboard/app';
-  import { NAME_APP } from '../Configurations';
-  import Cookies from 'universal-cookie';
+import {
+  AcceptedAdvice, CanceledAdvise, RequestedAdvice, TotalAdvice,
+  AdviseOfTheDay, UserDistribution, CarouselInfographics, WebAppAdvise
+} from '../components/_dashboard/app';
+import { NAME_APP } from '../Configurations';
+import Cookies from 'universal-cookie';
 
 function DashboardApp() {
   const cookies = new Cookies();
@@ -26,7 +28,7 @@ function DashboardApp() {
         <Grid container spacing={3}>
           {
             cookies.get('UserType') === 'N'
-            ?
+              ?
               <>
                 <Grid item xs={12} md={4} lg={8}>
                   <CarouselInfographics />
@@ -36,13 +38,13 @@ function DashboardApp() {
                   <AdviseOfTheDay />
                 </Grid>
               </>
-            :
+              :
               null
           }
 
           {
             cookies.get('UserType') === 'A'
-            ?
+              ?
               <>
 
                 <Grid item xs={12} md={4} lg={8}>
@@ -53,13 +55,13 @@ function DashboardApp() {
                   <AdviseOfTheDay />
                 </Grid>
               </>
-            :
+              :
               null
           }
 
           {
             cookies.get('UserType') === 'S'
-            ?
+              ?
               <>
                 <Grid item xs={12} sm={6} md={3}>
                   <TotalAdvice />
@@ -80,7 +82,7 @@ function DashboardApp() {
                   <UserDistribution />
                 </Grid>
               </>
-            :
+              :
               null
           }
 

--- a/src/pages/NewUser.js
+++ b/src/pages/NewUser.js
@@ -64,6 +64,8 @@ function NewUser() {
   useEffect(() => {
     if (!cookies.get('UserCode')) {
       navigate('/');
+    } else if (cookies.get('UserType') !== 'S') {
+      navigate('/dashboard');
     }
   });
 
@@ -493,24 +495,24 @@ function NewUser() {
                       </LoadingButton>
                       {
                         showAlertPost
-                        ?
+                          ?
                           <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'right' }} open={open} autoHideDuration={6000} onClose={handleClose}>
                             <Alert onClose={handleClose} severity="success" sx={{ width: '100%', boxShadow: 10 }}>
                               Se ha registrado con éxito
                             </Alert>
                           </Snackbar>
-                        :
+                          :
                           null
                       }
                       {
                         showAlert.show
-                        ?
+                          ?
                           <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'right' }} open={open} autoHideDuration={6000} onClose={handleClose}>
                             <Alert onClose={handleClose} severity="error" sx={{ width: '100%', boxShadow: 10 }}>
                               {showAlert.message}
                             </Alert>
                           </Snackbar>
-                        :
+                          :
                           null
                       }
                     </Stack>

--- a/src/pages/Reports.js
+++ b/src/pages/Reports.js
@@ -51,6 +51,8 @@ function Reports() {
     useEffect(() => {
         if (!cookies.get('UserCode')) {
             navigate('/');
+        } else if (cookies.get('UserType') === 'N') {
+            navigate('/dashboard');
         }
     });
 
@@ -163,9 +165,9 @@ function Reports() {
         advisorPhone: element.advisorPhone,
         counselingLocationInfo:
             element.advise_modality === 'V'
-            ?
+                ?
                 element.advise_url
-            :
+                :
                 `Edificio: ${element.building_name} - ${element.classroom_name}`,
         adviseDateRequest: dateTimeFormat(element.advise_date_request),
         adviseDateStart: dateTimeFormat(element.advise_date_start),
@@ -186,11 +188,11 @@ function Reports() {
                     </Typography>
                 </Stack>
                 <Card style={{ height: 472, padding: '24px' }}>
-                    <div style={{ height: '100%'}}>
+                    <div style={{ height: '100%' }}>
                         <DataGrid
                             rows={adviseList}
                             columns={columns}
-                            components={{Toolbar: GridToolbar}}
+                            components={{ Toolbar: GridToolbar }}
                             componentsProps={{ toolbar: { csvOptions: { utf8WithBom: true } } }}
                             localeText={esES.components.MuiDataGrid.defaultProps.localeText}
                             initialState={{

--- a/src/pages/Subjects.js
+++ b/src/pages/Subjects.js
@@ -22,6 +22,8 @@ function Subjects() {
     useEffect(() => {
         if (!cookies.get('UserCode')) {
             navigate('/');
+        } else if (cookies.get('UserType') !== 'N') {
+            navigate('/dashboard');
         }
     });
 
@@ -63,9 +65,9 @@ function Subjects() {
     const uniqueSubjects = () => {
         var subject = [];
         data.filter((element) => {
-            if(idUser !== undefined){
-                if(idUser.match(element.advise_advisor)){
-                    subject.push(element.advise_subject); 
+            if (idUser !== undefined) {
+                if (idUser.match(element.advise_advisor)) {
+                    subject.push(element.advise_subject);
                 }
             } else {
                 subject.push(element.advise_subject);
@@ -103,8 +105,8 @@ function Subjects() {
         var virtual = 0;
 
         dataResult.filter((element) => {
-            if(idUser !== undefined){
-                if(idUser.match(element.advise_advisor)){
+            if (idUser !== undefined) {
+                if (idUser.match(element.advise_advisor)) {
                     advisor.push(element.advise_advisor);
                     if (element.advise_modality === 'P') {
                         faceToFace = faceToFace + 1;
@@ -125,12 +127,12 @@ function Subjects() {
 
         var uniqueAdvisor = [...new Set(advisor)];
 
-        return ({ 
+        return ({
             id: idSubject,
             name: nameSubject,
             faceToFaceAdvise: faceToFace,
             virtalAdvise: virtual,
-            advisors: filterAdvisorData(uniqueAdvisor) 
+            advisors: filterAdvisorData(uniqueAdvisor)
         });
     };
 
@@ -157,9 +159,9 @@ function Subjects() {
                 <Grid container spacing={3}>
                     {
                         noRequest
-                        ?
+                            ?
                             <Wrong />
-                        :
+                            :
                             filterSubjectData().map(subject => (
                                 <Grid item xs={12} sm={6} md={4}>
                                     <Card>

--- a/src/pages/User.js
+++ b/src/pages/User.js
@@ -4,8 +4,10 @@ import { filter } from 'lodash';
 import { Icon } from '@iconify/react';
 import plusFill from '@iconify/icons-eva/plus-fill';
 import { sentenceCase } from 'change-case';
-import { Card, Table, Stack, Avatar, Button, Checkbox, TableRow, TableBody, TableCell, Container,
-  Typography, TableContainer, TablePagination } from '@mui/material';
+import {
+  Card, Table, Stack, Avatar, Button, Checkbox, TableRow, TableBody, TableCell, Container,
+  Typography, TableContainer, TablePagination
+} from '@mui/material';
 import Page from '../components/Page';
 import Label from '../components/Label';
 import Scrollbar from '../components/Scrollbar';
@@ -113,6 +115,8 @@ function User() {
   useEffect(() => {
     if (!cookies.get('UserCode')) {
       navigate('/');
+    } else if (cookies.get('UserType') !== 'S') {
+      navigate('/dashboard');
     }
   });
 
@@ -225,9 +229,9 @@ function User() {
           </Typography>
           {
             data <= 0 && isUserNotFound
-            ?
+              ?
               null
-            :
+              :
               <Button
                 variant="contained"
                 component={RouterLink}
@@ -242,9 +246,9 @@ function User() {
         {
 
           noRequest
-          ?
+            ?
             <Wrong />
-          :
+            :
             <Card>
               <UserListToolbar
                 numSelected={selected.length}

--- a/src/pages/UserEdit.js
+++ b/src/pages/UserEdit.js
@@ -64,6 +64,8 @@ function UserEdit() {
     peticionesGet();
     if (!cookies.get('UserCode')) {
       navigate('/');
+    } else if (cookies.get('UserType') !== 'S') {
+      navigate('/dashboard');
     }
   });
 
@@ -329,9 +331,9 @@ function UserEdit() {
                 variant="ghost"
                 color={
                   accountStatus === ''
-                  ?
+                    ?
                     (user.userx_status === 'I' && 'error') || 'success'
-                  :
+                    :
                     (accountStatus === 'I' && 'error') || 'success'
                 }
               >
@@ -362,9 +364,9 @@ function UserEdit() {
               </div>
               {
                 accountStatus === ''
-                ?
+                  ?
                   <Switch sx={{ pl: 2 }} onChange={() => setStatus(user.userx_status === 'I' ? 'A' : 'I')} checked={user.userx_status === 'I' ? false : true} />
-                :
+                  :
                   <Switch sx={{ pl: 2 }} onChange={() => setStatus(accountStatus === 'I' ? 'A' : 'I')} checked={accountStatus === 'I' ? false : true} />
               }
             </div>
@@ -383,9 +385,9 @@ function UserEdit() {
               </div>
               {
                 advisor === ''
-                ?
+                  ?
                   <Switch sx={{ pl: 2 }} onChange={() => changeSwitch('A')} checked={user.userx_type === 'A' ? true : false} />
-                :
+                  :
                   <Switch sx={{ pl: 2 }} onChange={() => { setAdvisor(!advisor); setAdmin(false); }} checked={advisor} />
               }
 
@@ -405,9 +407,9 @@ function UserEdit() {
               </div>
               {
                 admin === ''
-                ?
+                  ?
                   <Switch sx={{ pl: 2 }} onChange={() => changeSwitch('S')} checked={user.userx_type === 'S' ? true : false} />
-                :
+                  :
                   <Switch sx={{ pl: 2 }} onChange={() => { setAdmin(!admin); setAdvisor(false); }} checked={admin} />
               }
 
@@ -501,13 +503,13 @@ function UserEdit() {
 
                       {
                         showAlert.show
-                        ?
+                          ?
                           <Snackbar anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }} open={open} autoHideDuration={6000} onClose={handleClose}>
                             <Alert onClose={handleClose} severity={showAlert.color} sx={{ width: '100%', boxShadow: 10 }}>
                               {showAlert.message}
                             </Alert>
                           </Snackbar>
-                        :
+                          :
                           null
                       }
 


### PR DESCRIPTION
Se configura las vistas según el tipo de usuario, además se valida que el usuario no ingrese a través de la URL a otra vista que no le pertenece, si es así lo regresa al tablero.

Sería cuestión de quitar lo de  window.location.reload(); porque a veces se ve un poco feo, pero no encontré una forma de que se actualice por si solo, por mientras puede servir.

No se hizo la validación en añadir asesoría para evitar problemas.