### PR TITLE
Historial de asesorías

### DIFF
--- a/src/components/_dashboard/history/HistoryAdvisor.js
+++ b/src/components/_dashboard/history/HistoryAdvisor.js
@@ -1,0 +1,246 @@
+import { useEffect, useState } from 'react';
+import { useFormik, Form, FormikProvider } from 'formik';
+import * as Yup from 'yup';
+import { Icon } from '@iconify/react';
+import { WS_PATH } from '../../../Configurations';
+import MockImgAvatar from '../../../utils/mockImages';
+import calendarFill from '@iconify/icons-eva/calendar-fill';
+import clockFill from '@iconify/icons-eva/clock-fill';
+import downwardFill from '@iconify/icons-eva/arrow-ios-downward-fill';
+import pinFill from '@iconify/icons-eva/pin-fill';
+import videoFill from '@iconify/icons-eva/video-fill';
+import { LoadingButton } from '@mui/lab';
+import { Typography, Box, Stack, Grid, TextField, Divider, Accordion, Tooltip, AccordionSummary, AccordionDetails, Rating, Skeleton, Alert, Snackbar } from '@mui/material';
+import axios from 'axios';
+
+function dateFormat(date) {
+    var dateTimeArray = date.split('T');
+    var dateArray = dateTimeArray[0].split('-');
+    return `${dateArray[2]}/${dateArray[1]}/${dateArray[0]}`;
+}
+
+function timeFormat(dateStart, dateEnd) {
+    var dateTimeStartArray = dateStart.split('T');
+    var dateTimeEndArray = dateEnd.split('T');
+    var timeStartArray = dateTimeStartArray[1].split(':');
+    var timeEndArray = dateTimeEndArray[1].split(':');
+    return `${timeStartArray[0]}:${timeStartArray[1]} - ${timeEndArray[0]}:${timeEndArray[1]}`;
+}
+
+function HistoryAdvisor(props) {
+
+    const [advise, setAdvise] = useState({ advise_code: '' });
+    const [loading, setLoading] = useState(false);
+    const [showAlert, setShowAlert] = useState(false);
+    const [open, setOpen] = useState(false);
+
+    const requestGet = async () => {
+        await axios.get(`${WS_PATH}advises/${props.id}`)
+            .then(response => {
+                setAdvise(response.data);
+            }).catch(error => {
+                console.log(error);
+            });
+    }
+
+    useEffect(() => {
+        requestGet();
+    });
+
+    const handleClose = (event, reason) => {
+        if (reason === 'clickaway') {
+            return;
+        }
+        setShowAlert(false);
+    };
+
+    const peticionPutAdvise = async () => {
+        await axios.put(`${WS_PATH}advises/${props.id}`, {
+            advise_code: advise.advise_code,
+            advise_student: advise.advise_student,
+            advise_topic: getFieldProps("topic").value,
+            advise_subject: advise.advise_subject,
+            advise_advisor: advise.advise_advisor,
+            advise_school: advise.advise_school,
+            advise_building: advise.advise_building,
+            advise_classroom: advise.advise_classroom,
+            advise_date_request: advise.advise_date_request,
+            advise_date_start: advise.advise_date_start,
+            advise_date_ends: advise.advise_date_ends,
+            advise_modality: advise.advise_modality,
+            advise_url: advise.advise_url,
+            advise_comments: advise.advise_comments,
+            advise_status: advise.advise_status
+        })
+            .then((response) => {
+                setLoading(false);
+                setOpen(true);
+                setShowAlert(true);
+            })
+            .catch((error) => {
+                console.log(error);
+            });
+    };
+
+    const RegisterSchema = Yup.object().shape({
+        topic: Yup.string()
+            .required("No se ha añadido un tema")
+            .max(30, "Máximo 30 caracteres")
+    });
+
+    const formik = useFormik({
+        initialValues: {
+            topic: advise.advise_topic,
+        },
+        enableReinitialize: true,
+        validationSchema: RegisterSchema,
+        onSubmit: () => {
+            setLoading(true);
+            peticionPutAdvise();
+        }
+    });
+
+    const { errors, touched, handleSubmit, getFieldProps } = formik;
+
+    return (
+
+        advise.advise_code === ''
+            ?
+            <Skeleton variant="rectangular" height={90} />
+            :
+            <Accordion>
+                <AccordionSummary
+                    expandIcon={<Icon icon={downwardFill} width="26px" />}
+                    aria-controls="panel1a-content"
+                    id="panel1a-header"
+                >
+                    <Grid container>
+                        <Grid item xs={12} sm={6} md={3.5}>
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    width: 'fit-content',
+                                }}
+                            >
+                                <Tooltip title={advise.studentEmail} placement="top" arrow>
+                                    <Box
+                                        component="img"
+                                        src={`data:image/png;base64,${advise.studentImage !== '' ? advise.studentImage : MockImgAvatar()}`}
+                                        alt="advisorImage"
+                                        sx={{ textAlign: 'center', width: 70, borderRadius: 8, height: 70 }}
+                                    />
+                                </Tooltip>
+
+                                <Box sx={{ textAlign: 'center', marginLeft: '15px' }}>
+                                    <Typography gutterBottom variant="h6">
+                                        {`${advise.studentName} ${advise.studentLastName}`}
+                                    </Typography>
+                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                        {advise.subjectx_name}
+                                    </Typography>
+                                </Box>
+                            </Box>
+                        </Grid>
+                        <Divider orientation='vertical' variant='middle' flexItem />
+                        <Grid item xs={12} sm={5} md={2.5}>
+                            <Box sx={{ textAlign: 'center', alignItems: 'center', }}>
+                                <Typography gutterBottom variant="h6">
+                                    <Icon icon={calendarFill} width="15px" />&nbsp;Fecha
+                                </Typography>
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    {dateFormat(props.dateStart)}
+                                </Typography>
+                            </Box>
+                        </Grid>
+                        <Divider orientation='vertical' variant='middle' flexItem />
+                        <Grid item xs={12} sm={5} md={2.5}>
+                            <Box sx={{ textAlign: 'center', alignItems: 'center' }}>
+                                <Typography gutterBottom variant="h6">
+                                    <Icon icon={clockFill} width="15px" />&nbsp;Horario
+                                </Typography>
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    {timeFormat(props.dateStart, props.dateEnd)}
+                                </Typography>
+                            </Box>
+                        </Grid>
+                        <Divider orientation='vertical' variant='middle' flexItem />
+                        <Grid item xs={12} sm={5} md={2.5}>
+                            <Box sx={{ textAlign: 'center', alignItems: 'center' }}>
+                                <Typography gutterBottom variant="h6">
+                                    <Icon icon={advise.advise_modality === 'P' ? pinFill : videoFill} width="15px" />&nbsp;Lugar
+                                </Typography>
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    {
+                                        advise.advise_modality === 'V'
+                                            ?
+                                            `Código: ${advise.advise_url}`
+                                            :
+                                            `Edificio: ${advise.building_name} - ${advise.classroom_name}`
+                                    }
+                                </Typography>
+                            </Box>
+                        </Grid>
+                    </Grid>
+                </AccordionSummary>
+                <AccordionDetails>
+                    <FormikProvider value={formik}>
+                        <Form autoComplete="off" noValidate onSubmit={handleSubmit}>
+                            <Grid container spacing={2}>
+                                <Grid item xs={12} sm={11} md={10}>
+                                    <TextField
+                                        fullWidth
+                                        label="Tema"
+                                        variant="standard"
+                                        {...getFieldProps("topic")}
+                                        error={Boolean(touched.topic && errors.topic)}
+                                        helperText={touched.topic && errors.topic}
+                                    />
+                                </Grid>
+                                <Grid item xs={12} sm={6} md={2} >
+                                    <Stack style={{ display: 'flex', alignItems: 'center' }}>
+                                        <Rating
+                                            name="size-medium"
+                                            disabled
+                                            defaultValue={5} />
+                                    </Stack>
+                                </Grid>
+                                <Grid item xs={12} sm={12} md={12}>
+                                    <TextField
+                                        fullWidth
+                                        multiline
+                                        label="Comentario"
+                                        value={advise.advise_comments}
+                                        disabled
+                                    />
+                                </Grid>
+                                <Grid item xs={12} sm={12} md={12}>
+                                    <Stack style={{ display: 'flex', alignItems: 'flex-end' }}>
+                                        <LoadingButton
+                                            type="submit"
+                                            variant="contained"
+                                            style={{ width: 'fit-content' }}
+                                            loading={loading}
+                                        >
+                                            Guardar cambios
+                                        </LoadingButton>
+                                        {
+                                            showAlert
+                                                ?
+                                                <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'right' }} open={open} autoHideDuration={6000} onClose={handleClose} sx={{ mt: 10 }}>
+                                                    <Alert onClose={handleClose} severity="success" sx={{ width: '100%' }}>
+                                                        ¡Se guardaron los cambios con éxito!
+                                                    </Alert>
+                                                </Snackbar>
+                                                :
+                                                null
+                                        }
+                                    </Stack>
+                                </Grid>
+                            </Grid>
+                        </Form>
+                    </FormikProvider>
+                </AccordionDetails>
+            </Accordion >
+    );
+}
+export default HistoryAdvisor;

--- a/src/components/_dashboard/history/HistoryStudent.js
+++ b/src/components/_dashboard/history/HistoryStudent.js
@@ -1,0 +1,254 @@
+import { useEffect, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import { useFormik, Form, FormikProvider } from 'formik';
+import * as Yup from 'yup';
+import { Icon } from '@iconify/react';
+import { WS_PATH } from '../../../Configurations';
+import MockImgAvatar from '../../../utils/mockImages';
+import calendarFill from '@iconify/icons-eva/calendar-fill';
+import clockFill from '@iconify/icons-eva/clock-fill';
+import downwardFill from '@iconify/icons-eva/arrow-ios-downward-fill';
+import pinFill from '@iconify/icons-eva/pin-fill';
+import videoFill from '@iconify/icons-eva/video-fill';
+import { LoadingButton } from '@mui/lab';
+import { Typography, Box, Stack, Grid, TextField, Divider, Accordion, AccordionSummary, AccordionDetails, Rating, Skeleton, IconButton, Alert, Snackbar } from '@mui/material';
+import axios from 'axios';
+
+function dateFormat(date) {
+  var dateTimeArray = date.split('T');
+  var dateArray = dateTimeArray[0].split('-');
+  return `${dateArray[2]}/${dateArray[1]}/${dateArray[0]}`;
+}
+
+function timeFormat(dateStart, dateEnd) {
+  var dateTimeStartArray = dateStart.split('T');
+  var dateTimeEndArray = dateEnd.split('T');
+  var timeStartArray = dateTimeStartArray[1].split(':');
+  var timeEndArray = dateTimeEndArray[1].split(':');
+  return `${timeStartArray[0]}:${timeStartArray[1]} - ${timeEndArray[0]}:${timeEndArray[1]}`;
+}
+
+function HistoryStudent(props) {
+
+  const [advise, setAdvise] = useState({ advise_code: '' });
+  const [loading, setLoading] = useState(false);
+  const [showAlert, setShowAlert] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const requestGet = async () => {
+    await axios.get(`${WS_PATH}advises/${props.id}`)
+      .then(response => {
+        setAdvise(response.data);
+      }).catch(error => {
+        console.log(error);
+      });
+  }
+
+  useEffect(() => {
+    requestGet();
+  });
+
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setShowAlert(false);
+  };
+
+  const peticionPutAdvise = async () => {
+    await axios.put(`${WS_PATH}advises/${props.id}`, {
+      advise_code: advise.advise_code,
+      advise_student: advise.advise_student,
+      advise_topic: advise.advise_topic,
+      advise_subject: advise.advise_subject,
+      advise_advisor: advise.advise_advisor,
+      advise_school: advise.advise_school,
+      advise_building: advise.advise_building,
+      advise_classroom: advise.advise_classroom,
+      advise_date_request: advise.advise_date_request,
+      advise_date_start: advise.advise_date_start,
+      advise_date_ends: advise.advise_date_ends,
+      advise_modality: advise.advise_modality,
+      advise_url: advise.advise_url,
+      advise_comments: getFieldProps("comments").value,
+      advise_status: advise.advise_status
+    })
+      .then((response) => {
+        setLoading(false);
+        setOpen(true);
+        setShowAlert(true);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
+  const RegisterSchema = Yup.object().shape({
+    comments: Yup.string()
+      .required("No sea realizado ningún comentario")
+      .max(200, "Máximo 200 caracteres")
+  });
+
+  const formik = useFormik({
+    initialValues: {
+      comments: advise.advise_comments,
+    },
+    enableReinitialize: true,
+    validationSchema: RegisterSchema,
+    onSubmit: () => {
+      setLoading(true);
+      peticionPutAdvise();
+    }
+  });
+
+  const { errors, touched, handleSubmit, getFieldProps } = formik;
+
+  return (
+
+    advise.advise_code === ''
+      ?
+      <Skeleton variant="rectangular" height={90} />
+      :
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<Icon icon={downwardFill} width="26px" />}
+          aria-controls="panel1a-content"
+          id="panel1a-header"
+        >
+          <Grid container>
+            <Grid item xs={12} sm={6} md={3.5}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  width: 'fit-content',
+                }}
+              >
+                <IconButton
+                  to={`/dashboard/adviser-profile/${advise.advise_advisor}`}
+                  component={RouterLink}
+                  sx={{
+                    padding: 0,
+                    width: 70,
+                    height: 70
+                  }}>
+                  <Box
+                    component="img"
+                    src={`data:image/png;base64,${advise.advisorImage !== '' ? advise.advisorImage : MockImgAvatar()}`}
+                    alt="advisorImage"
+                    sx={{ textAlign: 'center', width: 70, borderRadius: 8, height: 70 }}
+                  />
+                </IconButton>
+
+                <Box sx={{ textAlign: 'center', marginLeft: '15px' }}>
+                  <Typography gutterBottom variant="h6">
+                    {`${advise.advisorName} ${advise.advisorLastName}`}
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    {advise.subjectx_name}
+                  </Typography>
+                </Box>
+              </Box>
+            </Grid>
+            <Divider orientation='vertical' variant='middle' flexItem />
+            <Grid item xs={12} sm={5} md={2.5}>
+              <Box sx={{ textAlign: 'center', alignItems: 'center', }}>
+                <Typography gutterBottom variant="h6">
+                  <Icon icon={calendarFill} width="15px" />&nbsp;Fecha
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  {dateFormat(props.dateStart)}
+                </Typography>
+              </Box>
+            </Grid>
+            <Divider orientation='vertical' variant='middle' flexItem />
+            <Grid item xs={12} sm={5} md={2.5}>
+              <Box sx={{ textAlign: 'center', alignItems: 'center' }}>
+                <Typography gutterBottom variant="h6">
+                  <Icon icon={clockFill} width="15px" />&nbsp;Horario
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  {timeFormat(props.dateStart, props.dateEnd)}
+                </Typography>
+              </Box>
+            </Grid>
+            <Divider orientation='vertical' variant='middle' flexItem />
+            <Grid item xs={12} sm={5} md={2.5}>
+              <Box sx={{ textAlign: 'center', alignItems: 'center' }}>
+                <Typography gutterBottom variant="h6">
+                  <Icon icon={advise.advise_modality === 'P' ? pinFill : videoFill} width="15px" />&nbsp;Lugar
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  {
+                    advise.advise_modality === 'V'
+                      ?
+                      `Código: ${advise.advise_url}`
+                      :
+                      `Edificio: ${advise.building_name} - ${advise.classroom_name}`
+                  }
+                </Typography>
+              </Box>
+            </Grid>
+          </Grid>
+        </AccordionSummary>
+        <AccordionDetails>
+          <FormikProvider value={formik}>
+            <Form autoComplete="off" noValidate onSubmit={handleSubmit}>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={11} md={10}>
+                  <TextField
+                    fullWidth
+                    label="Tema"
+                    value={advise.advise_topic}
+                    variant="standard"
+                    disabled
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6} md={2} >
+                  <Stack style={{ display: 'flex', alignItems: 'center' }}>
+                    <Rating
+                      name="size-medium"
+                      disabled
+                      defaultValue={5} />
+                  </Stack>
+                </Grid>
+                <Grid item xs={12} sm={12} md={12}>
+                  <TextField
+                    fullWidth
+                    multiline
+                    label="Comentario"
+                    {...getFieldProps("comments")}
+                    error={Boolean(touched.comments && errors.comments)}
+                    helperText={touched.comments && errors.comments}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={12} md={12}>
+                  <Stack style={{ display: 'flex', alignItems: 'flex-end' }}>
+                    <LoadingButton
+                      type="submit"
+                      variant="contained"
+                      style={{ width: 'fit-content' }}
+                      loading={loading}
+                    >
+                      Guardar cambios
+                    </LoadingButton>
+                    {
+                      showAlert
+                        ?
+                        <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'right' }} open={open} autoHideDuration={6000} onClose={handleClose} sx={{ mt: 10 }}>
+                          <Alert onClose={handleClose} severity="success" sx={{ width: '100%' }}>
+                            ¡Se guardaron los cambios con éxito!
+                          </Alert>
+                        </Snackbar>
+                        :
+                        null
+                    }
+                  </Stack>
+                </Grid>
+              </Grid>
+            </Form>
+          </FormikProvider>
+        </AccordionDetails>
+      </Accordion >
+  );
+}
+export default HistoryStudent;

--- a/src/components/_dashboard/history/index.js
+++ b/src/components/_dashboard/history/index.js
@@ -1,0 +1,2 @@
+export { default as HistoryStudent } from './HistoryStudent';
+export { default as HistoryAdvisor } from './HistoryAdvisor';

--- a/src/layouts/dashboard/SidebarConfig.js
+++ b/src/layouts/dashboard/SidebarConfig.js
@@ -6,6 +6,7 @@ import fileTextFill from '@iconify/icons-eva/file-text-fill';
 import bookFill from '@iconify/icons-eva/book-fill';
 import clipBoardFill from '@iconify/icons-eva/clipboard-fill';
 import calendarFill from '@iconify/icons-eva/calendar-fill';
+import clockFill from '@iconify/icons-eva/clock-fill';
 import infoFill from '@iconify/icons-eva/info-fill';
 
 const getIcon = (name) => <Icon icon={name} width={22} height={22} />;
@@ -50,6 +51,11 @@ const sidebarConfig = [
     title: 'Calendario',
     path: '/dashboard/calendar',
     icon: getIcon(calendarFill)
+  },
+  {
+    title: 'Historial',
+    path: '/dashboard/history',
+    icon: getIcon(clockFill)
   },
   {
     title: 'acerca de',

--- a/src/pages/History.js
+++ b/src/pages/History.js
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Container, Typography, Grid, Card } from '@mui/material';
+import Page from '../components/Page';
+import { HistoryStudent, HistoryAdvisor } from '../components/_dashboard/history';
+import { Wrong } from '../components/_dashboard/errors';
+import { WS_PATH, NAME_APP } from '../Configurations';
+import Cookies from 'universal-cookie';
+import axios from 'axios';
+
+function History() {
+
+    const [advise, setAdvise] = useState([]);
+    const [noRequest, setNoRequest] = useState(false);
+
+    const cookies = new Cookies();
+    const navigate = useNavigate();
+    useEffect(() => {
+        if (!cookies.get('UserCode')) {
+            navigate('/');
+        }
+    });
+
+    const requestGet = async () => {
+        await axios.get(`${WS_PATH}advises`)
+            .then(response => {
+                setAdvise(response.data);
+            }).catch(error => {
+                if (error.request) {
+                    console.log(error.request);
+                    setNoRequest(true);
+                }
+                else {
+                    console.log(error);
+                }
+            });
+    }
+
+    useEffect(() => {
+        requestGet();
+    }, []);
+
+    const filterSortAdvises = () => {
+        var data = [];
+        var todayD = new Date();
+        advise.filter((element) => {
+            var todayA = new Date(element.advise_date_ends);
+            if ((element.advise_status === 'A') && (todayA < todayD)) {
+                if (cookies.get('UserType') === 'N') {
+                    if (element.advise_student === cookies.get('UserCode')) {
+                        data.push(element);
+                    }
+                } else if (cookies.get('UserType') === 'A') {
+                    if (element.advise_advisor === cookies.get('UserCode')) {
+                        data.push(element);
+                    }
+                }
+            }
+            return 0;
+        });
+        var sortedArray = data.sort(function (a, b) { a = new Date(a.advise_date_ends); b = new Date(b.advise_date_ends); return b < a ? -1 : b < a ? 1 : 0; });
+        return sortedArray;
+    };
+
+    return (
+        <Page title={`Asesora${NAME_APP} | Historial`}>
+            <Container>
+                <Typography variant="h4" sx={{ mb: 5 }}>
+                    Historial
+                </Typography>
+                <Grid container spacing={3}>
+                    {
+                        noRequest
+                            ?
+                            <Wrong />
+                            :
+                            filterSortAdvises().map(element => (
+                                <Grid item xs={12} sm={12} md={12}>
+                                    <Card>
+                                        {
+                                            cookies.get('UserType') === 'N'
+                                                ?
+                                                <HistoryStudent
+                                                    id={element.advise_code}
+                                                    dateStart={element.advise_date_start}
+                                                    dateEnd={element.advise_date_ends}
+                                                />
+                                                :
+                                                <HistoryAdvisor
+                                                    id={element.advise_code}
+                                                    dateStart={element.advise_date_start}
+                                                    dateEnd={element.advise_date_ends}
+                                                />
+                                        }
+                                    </Card>
+                                </Grid>
+                            ))
+                    }
+                </Grid>
+            </Container>
+        </Page>
+    );
+}
+
+export default History;

--- a/src/pages/NewAdvise.js
+++ b/src/pages/NewAdvise.js
@@ -51,6 +51,7 @@ function dateTimeFormat(date, time) {
 
 function NewAdvises() {
   const [modality, setModality] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [showAlertPost, setShowAlertPost] = useState(false);
   const [open, setOpen] = useState(false);
   const [dateAdvise, setDateAdvise] = useState(null);
@@ -180,6 +181,7 @@ function NewAdvises() {
     },
     validate,
     onSubmit: () => {
+      setLoading(true);
       postAdvise();
     },
   });
@@ -202,6 +204,7 @@ function NewAdvises() {
       advise_status: 'S'
     })
       .then((response) => {
+        setLoading(false);
         setShowAlertPost(true);
         setOpen(true);
       })
@@ -507,6 +510,7 @@ function NewAdvises() {
                       <LoadingButton
                         type="submit"
                         variant="contained"
+                        loading={loading}
                         style={{ width: 'fit-content' }}
                       >
                         Guardar cambios

--- a/src/routes.js
+++ b/src/routes.js
@@ -20,6 +20,7 @@ import NotFound from './pages/Page404';
 import { AdvisorProfile } from './components/_dashboard/advisers';
 import Next from './pages/Next';
 import Calendar from './pages/Calendar';
+import History from './pages/History';
 
 function Router() {
   return useRoutes([
@@ -66,6 +67,7 @@ function Router() {
         { path: 'my-profile', element: <MyProfile /> },
         { path: 'reports', element: <Reports /> },
         { path: 'calendar', element: <Calendar /> },
+        { path: 'history', element: <History /> },
         { path: '404', element: <NotFound /> },
         { path: '*', element: <Navigate to="/404" /> },
       ]


### PR DESCRIPTION
Se realiza la interfaz para mostrar el historial de asesorías impartidas tanto para estudiante y asesor.

General:
-Se realizar filtrado de asesorías con status 'A', se ordena por fecha de termino. 
-Se crea un diseño tipo acordeón donde se muestran los datos principales y al extenderse muestra un espacio para a ver o añadir información.
-Se configura la vista según el tipo de usuario en sesión.
- Diseño responsive en la mayoría de dispositivos.

Estudiante:
- Al hacer clic en la imagen del asesor puede ir al perfil del mismo.
- Puede añadir comentarios acerca de la asesoría.
- Puede observar el tema de la asesoría.

Asesor:
- Al pasar el mouse puede observar el correo del alumno.
- Es el encargado de añadir el tema visto en la asesoría.
- Puede observar los comentarios del estudiante para tomarlo como retroalimentación.

Diseño:
![image](https://user-images.githubusercontent.com/97417638/167270999-880da729-17c8-4a91-8564-a0e92cb4c3d2.png)
![image](https://user-images.githubusercontent.com/97417638/167271038-1a89bed0-915e-49e4-ab5b-48eaaef6a5ab.png)
